### PR TITLE
[BUGFIX][PHP7] thrown TypeError not catched

### DIFF
--- a/Security/Authorization/Voter/ArticleVoter.php
+++ b/Security/Authorization/Voter/ArticleVoter.php
@@ -49,6 +49,10 @@ class ArticleVoter implements VoterInterface
         {
             return false;
         }
+        catch(\Error $e)
+        {
+            return false;
+        }
 
     }
 


### PR DESCRIPTION
PHP7 introduced the Error (throwable) class, which acts like Exceptions
but it doesn't have any relation with the Exception base class.
try-catch blocks which only catch exceptions needs to be updated to work
with this new base class.
