### PR TITLE
Use reflection for security check on interface implementation

### DIFF
--- a/Security/Authorization/Voter/ArticleVoter.php
+++ b/Security/Authorization/Voter/ArticleVoter.php
@@ -34,22 +34,13 @@ class ArticleVoter implements VoterInterface
     {
         try
         {
-            $testObject = new $class();
-
-            if ($testObject instanceof ArticleInterface)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            $rc1 = new \ReflectionClass($class);
+            return in_array(ArticleInterface::class, $rc1->getInterfaceNames(), true);
         }
         catch(\Exception $e)
         {
             return false;
         }
-
     }
 
     public function vote(TokenInterface $token, $object, array $attributes)


### PR DESCRIPTION
Fixing php7+ which hard-crash on a constructor with inappropriate arguments